### PR TITLE
Logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -21,6 +22,7 @@
         "@supabase/supabase-js": "^2.57.2",
         "bcrypt": "^6.0.0",
         "buffer-to-stream": "^1.0.0",
+        "cache-manager-redis-store": "^3.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "cloudinary": "^1.41.3",
@@ -30,6 +32,7 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.3",
+        "redis": "^5.8.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "streamifier": "^0.1.1",
@@ -2068,6 +2071,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2094,6 +2104,19 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -2679,6 +2702,66 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.8.2.tgz",
+      "integrity": "sha512-855DR0ChetZLarblio5eM0yLwxA9Dqq50t8StXKp5bAtLT0G+rZ+eRzzqxl37sPqQKjUudSYypz55o6nNhbz0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.2.tgz",
+      "integrity": "sha512-WtMScno3+eBpTac1Uav2zugXEoXqaU23YznwvFgkPwBQVwEHTDgOG7uEAObtZ/Nyn8SmAMbqkEubJaMOvnqdsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.8.2.tgz",
+      "integrity": "sha512-uxpVfas3I0LccBX9rIfDgJ0dBrUa3+0Gc8sEwmQQH0vHi7C1Rx1Qn8Nv1QWz5bohoeIXMICFZRcyDONvum2l/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.8.2.tgz",
+      "integrity": "sha512-cNv7HlgayavCBXqPXgaS97DRPVWFznuzsAmmuemi2TMCx5scwLiP50TeZvUS06h/MG96YNPe6A0Zt57yayfxwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.8.2.tgz",
+      "integrity": "sha512-g2NlHM07fK8H4k+613NBsk3y70R2JIM2dPMSkhIjl2Z17SYvaYKdusz85d7VYOrZBWtDrHV/WD2E3vGu+zni8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.2"
       }
     },
     "node_modules/@scarf/scarf": {
@@ -4580,6 +4663,110 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.0.tgz",
+      "integrity": "sha512-GRv0Ji8Xgqtrg1Mmi4ygYpIt+SOApQNjJb5+rYIl+5y3u+tyBf+Csx79LL4wQjKLio63A6x1OpuBzhMzRv9jJg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "keyv": "^5.5.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cache-manager-redis-store/-/cache-manager-redis-store-3.0.1.tgz",
+      "integrity": "sha512-o560kw+dFqusC9lQJhcm6L2F2fMKobJ5af+FoR2PdnMVdpQ3f3Bz6qzvObTGyvoazQJxjQNWgMQeChP4vRTuXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "redis": "^4.3.1"
+      },
+      "engines": {
+        "node": ">= 16.18.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/cache-manager-redis-store/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4904,6 +5091,15 @@
       "license": "MIT",
       "peerDependencies": {
         "lodash": ">=4.0"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -6026,6 +6222,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -6219,6 +6425,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -7808,13 +8023,13 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
+      "integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.0"
       }
     },
     "node_modules/leven": {
@@ -9247,6 +9462,22 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.8.2.tgz",
+      "integrity": "sha512-31vunZj07++Y1vcFGcnNWEf5jPoTkGARgfWI4+Tk55vdwHxhAvug8VEtW7Cx+/h47NuJTEg/JL77zAwC6E0OeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.8.2",
+        "@redis/client": "5.8.2",
+        "@redis/json": "5.8.2",
+        "@redis/search": "5.8.2",
+        "@redis/time-series": "5.8.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -32,6 +33,7 @@
     "@supabase/supabase-js": "^2.57.2",
     "bcrypt": "^6.0.0",
     "buffer-to-stream": "^1.0.0",
+    "cache-manager-redis-store": "^3.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cloudinary": "^1.41.3",
@@ -41,6 +43,7 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.3",
+    "redis": "^5.8.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "streamifier": "^0.1.1",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Body, HttpCode, HttpStatus, Get, UseGuards, Req } fro
 import { AuthService } from './auth.service';
 import { StudioOwnerRegisterDto } from 'src/users/dto/owner.dto';
 import { LoginDto } from './dto/login.dto';
-import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Auth')
@@ -57,7 +57,6 @@ export class AuthController {
   }
 
   // --- Rutas para Google OAuth ---
-
   @ApiOperation({ summary: 'Iniciar sesión con Google (Inicia el flujo)' })
   @ApiResponse({ status: 302, description: 'Redirige al login de Google.' })
   @Get('google/login')
@@ -73,5 +72,14 @@ export class AuthController {
   handleGoogleCallback(@Req() req) {
     return this.authService.googleLogin(req);
   }
-}
 
+  @Post('logout')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'))
+  @HttpCode(HttpStatus.OK)
+  async logout(@Req() req) {
+    // El req.user contiene el payload del token y el token mismo
+    const token = req.headers.authorization.split(' ')[1];
+    return this.authService.logout(token);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,30 +2,40 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from 'src/users/users.module';
-import { JwtModule } from '@nestjs/jwt';
 import { StudiosModule } from 'src/studios/studios.module';
-import { JwtStrategy } from './jwt-strategy';
-import { PassportModule } from '@nestjs/passport';
-import { GoogleStrategy } from './google.strategy'; // 1. Importar la GoogleStrategy
+import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtStrategy } from './jwt-strategy';
+import { TokenBlacklistService } from './token-blacklist.service';
+import { CacheModule } from '@nestjs/cache-manager';
+import { redisStore } from 'cache-manager-redis-store';
 
 @Module({
   imports: [
     UsersModule,
     StudiosModule,
-    PassportModule,
-    // Configuración asíncrona para leer variables de entorno de forma segura
+    ConfigModule,
     JwtModule.registerAsync({
-      imports: [ConfigModule], // Importar ConfigModule para usar ConfigService
+      imports: [ConfigModule],
+      inject: [ConfigService],
       useFactory: async (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'), // Leer el secret desde .env
-        signOptions: { expiresIn: '1h' },
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '1h' }, // Ejemplo: tokens expiran en 1 hora
       }),
-      inject: [ConfigService], // Inyectar ConfigService en la factory
+    }),
+    // Configuración de Cache para Redis
+    CacheModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      isGlobal: true, // Hace el CacheModule disponible globalmente
+      useFactory: async (configService: ConfigService) => ({
+        store: redisStore,
+        host: configService.get<string>('REDIS_HOST'),
+        port: configService.get<number>('REDIS_PORT'),
+      }),
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, GoogleStrategy], // 2. Añadir GoogleStrategy como provider
+  providers: [AuthService, JwtStrategy, TokenBlacklistService], // Se añade el nuevo servicio
 })
 export class AuthModule {}
-

--- a/src/auth/token-blacklist.service.ts
+++ b/src/auth/token-blacklist.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
+
+@Injectable()
+export class TokenBlacklistService {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  /**
+   * Agrega un token a la lista negra.
+   * @param token El token JWT a invalidar.
+   * @param exp La fecha de expiración del token (en segundos desde epoch).
+   */
+  async blacklist(token: string, exp: number): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+    const ttl = exp - now; // Time-to-live en segundos
+
+    if (ttl > 0) {
+      // Guardamos el token en Redis con un TTL igual al tiempo que le queda de vida.
+      // El valor 'blacklisted' es solo un placeholder.
+      await this.cacheManager.set(token, 'blacklisted', ttl * 1000); // ttl en milisegundos
+    }
+  }
+
+  /**
+   * Verifica si un token está en la lista negra.
+   * @param token El token JWT a verificar.
+   * @returns true si el token está en la lista, false en caso contrario.
+   */
+  async isBlacklisted(token: string): Promise<boolean> {
+    const result = await this.cacheManager.get(token);
+    return !!result; // Devuelve true si encuentra algo, false si no.
+  }
+}


### PR DESCRIPTION
Hemos creado un sistema de cierre de sesión seguro que invalida los tokens de forma inmediata en el servidor.

A diferencia del método simple donde solo se borra el token en el navegador (lo que lo deja activo hasta que expira), nuestro nuevo flujo es más robusto:

    Creamos un endpoint /auth/logout que, al ser llamado, toma el token del usuario y lo añade a una "lista negra" (blacklist).

    Esta lista se gestiona con una base de datos en memoria (Redis), lo que la hace extremadamente rápida.

    Ahora, cada vez que se intenta usar un token para acceder a una ruta protegida, el sistema primero verifica si está en esa lista. Si lo está, la petición es rechazada al instante, aunque el token no haya expirado.

En resumen, aseguramos que cuando un usuario cierra sesión, su token queda inutilizable de inmediato, cerrando posibles brechas de seguridad.