### PR TITLE
implementacion-flujo pasarela de pagos/ aun no se hacen pruebas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/nodemailer": "^7.0.1",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
+        "body-parser": "^2.2.0",
         "buffer-to-stream": "^1.0.0",
         "cache-manager-redis-store": "^3.0.1",
         "class-transformer": "^0.5.1",
@@ -41,6 +42,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "streamifier": "^0.1.1",
+        "stripe": "^18.5.0",
         "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.26"
       },
@@ -59,6 +61,7 @@
         "@types/passport": "^1.0.17",
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-jwt": "^4.0.1",
+        "@types/stripe": "^8.0.416",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -4593,6 +4596,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stripe": {
+      "version": "8.0.416",
+      "resolved": "https://registry.npmjs.org/@types/stripe/-/stripe-8.0.416.tgz",
+      "integrity": "sha512-LDA574j7g30dg4R+SI1JIpkS+rkIuXgbe6+/qlf62avd7ZNntbbl2DYZwAIj9CfJYVh7FG/PLeoNB5OXTsEehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stripe": "*"
+      }
     },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
@@ -11600,6 +11613,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/nodemailer": "^7.0.1",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
+    "body-parser": "^2.2.0",
     "buffer-to-stream": "^1.0.0",
     "cache-manager-redis-store": "^3.0.1",
     "class-transformer": "^0.5.1",
@@ -52,6 +53,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "streamifier": "^0.1.1",
+    "stripe": "^18.5.0",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.26"
   },
@@ -70,6 +72,7 @@
     "@types/passport": "^1.0.17",
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-jwt": "^4.0.1",
+    "@types/stripe": "^8.0.416",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { FileUploadModule } from './file-upload/file-upload.module';
 import { RoomsModule } from './rooms/rooms.module';
 import { OwnersModule } from './owner/owner.module';
 import { OwnersController } from './owner/owner.controller';
+import { PaymentsModule } from './payment/payment.module';
 
 @Module({
   imports: [
@@ -46,9 +47,9 @@ import { OwnersController } from './owner/owner.controller';
     FileUploadModule,
     RoomsModule,
     OwnersModule,
+    PaymentsModule,
   ],
   controllers: [AppController, OwnersController],
   providers: [AppService],
 })
 export class AppModule {}
-

--- a/src/bookings/bookings.controller.ts
+++ b/src/bookings/bookings.controller.ts
@@ -14,7 +14,12 @@ import { RolesGuard } from 'src/auth/guard/roles.guard';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { UserRole } from 'src/auth/enum/roles.enum';
 import { CreateBookingDto } from './dto/create-booking';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 
 @ApiTags('Bookings')
 @ApiBearerAuth() // CAMBIO AQUÍ: Se aplica la seguridad a todo el controlador
@@ -39,7 +44,9 @@ export class BookingsController {
 
   // --- RUTAS PARA DUEÑOS DE ESTUDIO ---
 
-  @ApiOperation({ summary: 'Obtener todas las reservas de mis estudios (solo dueño)' })
+  @ApiOperation({
+    summary: 'Obtener todas las reservas de mis estudios (solo dueño)',
+  })
   @ApiResponse({ status: 200, description: 'Lista de reservas recuperada' })
   @ApiResponse({ status: 401, description: 'No autenticado' })
   // CAMBIO AQUÍ: Se documenta el error de rol no autorizado
@@ -60,10 +67,7 @@ export class BookingsController {
   @Patch('owner/:bookingId/confirm')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.STUDIO_OWNER)
-  async confirmBooking(
-    @Param('bookingId') bookingId: string,
-    @Request() req,
-  ) {
+  async confirmBooking(@Param('bookingId') bookingId: string, @Request() req) {
     return this.bookingsService.confirmBooking(bookingId, req.user);
   }
 
@@ -76,10 +80,7 @@ export class BookingsController {
   @Patch('owner/:bookingId/reject')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(UserRole.STUDIO_OWNER)
-  async rejectBooking(
-    @Param('bookingId') bookingId: string,
-    @Request() req,
-  ) {
+  async rejectBooking(@Param('bookingId') bookingId: string, @Request() req) {
     return this.bookingsService.rejectBooking(bookingId, req.user);
   }
 }

--- a/src/bookings/dto/bookings.entity.ts
+++ b/src/bookings/dto/bookings.entity.ts
@@ -8,6 +8,7 @@ import {
 import { Studio } from 'src/studios/entities/studio.entity';
 import { User } from 'src/users/entities/user.entity';
 import { BookingStatus } from '../enum/enums-bookings';
+import { Room } from 'src/rooms/entities/room.entity';
 
 @Entity('bookings')
 export class Booking {
@@ -35,5 +36,23 @@ export class Booking {
 
   @CreateDateColumn()
   createdAt: Date;
-}
 
+  @ManyToOne(() => Room, (room) => room, { nullable: true, eager: true })
+  room: Room;
+
+  @Column('decimal', { precision: 10, scale: 2, nullable: true })
+  totalPrice: number;
+
+  @Column({
+    type: 'enum',
+    enum: ['PENDING', 'SUCCEEDED', 'FAILED'], // NEW
+    default: 'PENDING',
+  })
+  paymentStatus: string;
+
+  @Column({ nullable: true })
+  paymentIntentId: string;
+
+  @Column({ default: false })
+  isPaid: boolean;
+}

--- a/src/bookings/dto/create-booking.ts
+++ b/src/bookings/dto/create-booking.ts
@@ -15,7 +15,10 @@ export class CreateBookingDto {
     example: '2025-09-03T10:00:00Z',
   })
   @IsNotEmpty({ message: 'La fecha de inicio es obligatoria.' })
-  @IsDateString({}, { message: 'La fecha de inicio debe ser una fecha válida.' })
+  @IsDateString(
+    {},
+    { message: 'La fecha de inicio debe ser una fecha válida.' },
+  )
   startTime: Date;
 
   @ApiProperty({
@@ -25,4 +28,12 @@ export class CreateBookingDto {
   @IsNotEmpty({ message: 'La fecha de fin es obligatoria.' })
   @IsDateString({}, { message: 'La fecha de fin debe ser una fecha válida.' })
   endTime: Date;
+
+  @ApiProperty({
+    description: 'ID de la room (sala) dentro del studio que se reserva',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsNotEmpty({ message: 'El ID de la sala (roomId) es obligatorio.' })
+  @IsUUID('4', { message: 'El ID de la sala debe ser un UUID válido.' })
+  roomId: string;
 }

--- a/src/bookings/enum/paymentStatus.ts
+++ b/src/bookings/enum/paymentStatus.ts
@@ -1,0 +1,5 @@
+export enum PaymentStatus {
+  PENDING = 'PENDIENTE',
+  SUCCEEDED = 'COMPLETADO',
+  FAILED = 'FALLIDO',
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 // main.ts
-
+import * as bodyParser from 'body-parser';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
@@ -46,6 +46,8 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
+
+  app.use('/payments/webhook', bodyParser.raw({ type: 'application/json' }));
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/src/payment/dto/Create-Membership-Paymentdto.ts
+++ b/src/payment/dto/Create-Membership-Paymentdto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsEnum } from 'class-validator';
+
+export enum MembershipPlan {
+  MONTHLY = 'MONTHLY',
+  YEARLY = 'YEARLY',
+}
+
+export class CreateMembershipPaymentDto {
+  @ApiProperty({ description: 'Plan de membresía', enum: MembershipPlan })
+  @IsNotEmpty()
+  @IsEnum(MembershipPlan)
+  plan: MembershipPlan;
+}

--- a/src/payment/dto/create-payment.dto.ts
+++ b/src/payment/dto/create-payment.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID, IsArray, ArrayUnique } from 'class-validator';
+
+export class CreatePaymentDto {
+  @ApiProperty({
+    description: 'ID de la reserva',
+    example: '770e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsNotEmpty()
+  @IsUUID('4')
+  bookingId: string;
+
+  @ApiProperty({
+    description: 'IDs de los instrumentos seleccionados (opcional)',
+    example: ['550e8400-e29b-41d4-a716-446655440001'],
+    required: false,
+  })
+  @IsArray()
+  @ArrayUnique()
+  instrumentIds?: string[];
+}

--- a/src/payment/dto/update-payment.dto.ts
+++ b/src/payment/dto/update-payment.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePaymentDto } from './create-payment.dto';
+
+export class UpdatePaymentDto extends PartialType(CreatePaymentDto) {}

--- a/src/payment/entities/payment.entity.ts
+++ b/src/payment/entities/payment.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Booking } from 'src/bookings/dto/bookings.entity';
+
+@Entity('payments')
+export class Payment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Booking, { nullable: false, eager: true })
+  @JoinColumn({ name: 'bookingId' })
+  booking: Booking;
+
+  @Column()
+  stripePaymentIntentId: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  amount: number;
+
+  @Column({ default: 'pending' })
+  status: string;
+
+  @Column({ length: 10, default: 'usd' })
+  currency: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Request,
+  Get,
+  Param,
+} from '@nestjs/common';
+import { PaymentsService } from './payment.service';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from 'src/auth/guard/roles.guard';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { UserRole } from 'src/auth/enum/roles.enum';
+import { CreatePaymentDto } from './dto/create-payment.dto';
+import { CreateMembershipPaymentDto } from './dto/Create-Membership-Paymentdto';
+import { User } from 'src/users/entities/user.entity';
+import { Booking } from 'src/bookings/dto/bookings.entity';
+import { Stripe } from 'stripe';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+
+@ApiTags('Payments')
+@ApiBearerAuth()
+@Controller('payments')
+export class PaymentsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  // 🔹 Pago de reserva
+  @Post('booking')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.MUSICIAN)
+  @ApiOperation({
+    summary: 'Pagar reserva de sala + instrumentos (solo músicos)',
+  })
+  @ApiResponse({ status: 201, description: 'PaymentIntent creado' })
+  async createBookingPayment(
+    @Request() req: { user: User },
+    @Body() dto: CreatePaymentDto,
+  ): Promise<{
+    clientSecret: string;
+    bookingId: string;
+    paymentIntentId: string;
+    totalPrice: number;
+  }> {
+    return this.paymentsService.createBookingPayment(req.user, dto);
+  }
+
+  // 🔹 Pago de membresía
+  @Post('membership')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.STUDIO_OWNER)
+  @ApiOperation({ summary: 'Pagar membresía mensual/anual (solo dueños)' })
+  @ApiResponse({
+    status: 201,
+    description: 'PaymentIntent de membresía creado',
+  })
+  async createMembershipPayment(
+    @Request() req: { user: User },
+    @Body() dto: CreateMembershipPaymentDto,
+  ): Promise<{ clientSecret: string; amount: number }> {
+    return this.paymentsService.createMembershipPayment(req.user, dto);
+  }
+
+  // 🔹 Confirmación de pago
+  @Get('confirm/:paymentIntentId')
+  @ApiOperation({ summary: 'Confirmar estado de un PaymentIntent' })
+  async confirmPayment(
+    @Param('paymentIntentId') paymentIntentId: string,
+  ): Promise<
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    Booking | { studioId: string; isActive: boolean } | Stripe.PaymentIntent
+  > {
+    return this.paymentsService.confirmPayment(paymentIntentId);
+  }
+}

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { PaymentsService } from './payment.service';
+import { PaymentsController } from './payment.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Booking } from 'src/bookings/dto/bookings.entity';
+import { Room } from 'src/rooms/entities/room.entity';
+import { Instruments } from 'src/instrumentos/entities/instrumento.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Studio } from 'src/studios/entities/studio.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Booking, Room, Instruments, User, Studio]),
+  ],
+  controllers: [PaymentsController],
+  providers: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import Stripe from 'stripe';
+import { Booking } from 'src/bookings/dto/bookings.entity';
+import { Room } from 'src/rooms/entities/room.entity';
+import { Instruments } from 'src/instrumentos/entities/instrumento.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Studio } from 'src/studios/entities/studio.entity';
+import { UserRole } from 'src/auth/enum/roles.enum';
+import { CreatePaymentDto } from './dto/create-payment.dto';
+import {
+  CreateMembershipPaymentDto,
+  MembershipPlan,
+} from './dto/Create-Membership-Paymentdto';
+
+@Injectable()
+export class PaymentsService {
+  private stripe: Stripe;
+
+  constructor(
+    @InjectRepository(Booking)
+    private readonly bookingRepo: Repository<Booking>,
+    @InjectRepository(Room) private readonly roomRepo: Repository<Room>,
+    @InjectRepository(Instruments)
+    private readonly instrumentRepo: Repository<Instruments>,
+    @InjectRepository(User) private readonly userRepo: Repository<User>,
+    @InjectRepository(Studio) private readonly studioRepo: Repository<Studio>,
+  ) {
+    const stripeKey = process.env.STRIPE_SECRET_KEY;
+    if (!stripeKey) throw new Error('STRIPE_SECRET_KEY no definido');
+
+    this.stripe = new Stripe(stripeKey, { apiVersion: '2025-08-27.basil' });
+  }
+
+  // 🔹 Pago de reserva por músicos
+  async createBookingPayment(
+    user: User,
+    dto: CreatePaymentDto,
+  ): Promise<{
+    clientSecret: string;
+    bookingId: string;
+    paymentIntentId: string;
+    totalPrice: number;
+  }> {
+    if (user.role !== UserRole.MUSICIAN) {
+      throw new ForbiddenException('Solo músicos pueden pagar reservas');
+    }
+
+    const booking = await this.bookingRepo.findOne({
+      where: { id: dto.bookingId },
+      relations: ['room', 'studio', 'musician'],
+    });
+
+    if (!booking) throw new NotFoundException('Reserva no encontrada');
+    if (booking.isPaid) throw new ForbiddenException('Reserva ya pagada');
+    if (!booking.room)
+      throw new BadRequestException('La reserva debe tener una sala asignada');
+
+    // 🔹 Verificar que el estudio esté activo
+    if (!booking.studio.isActive) {
+      throw new ForbiddenException(
+        'El estudio no está activo. No se pueden recibir reservas.',
+      );
+    }
+
+    // 🔹 Calcular precio de sala
+    const hours = this.getHours(booking.startTime, booking.endTime);
+    const roomPrice = Number(booking.room.pricePerHour) * hours;
+
+    // 🔹 Calcular precio de instrumentos
+    let instrumentsPrice = 0;
+    let instrumentsList: Instruments[] = [];
+    if (dto.instrumentIds?.length) {
+      instrumentsList = await this.instrumentRepo.find({
+        where: { id: In(dto.instrumentIds) },
+      });
+      instrumentsPrice = instrumentsList.reduce(
+        (sum, i) => sum + Number(i.price),
+        0,
+      );
+    }
+
+    // 🔹 Comisiones y totales
+    const roomCommission = roomPrice * 0.15; // 15% app
+    const roomOwnerAmount = roomPrice * 0.85; // 85% para dueño
+    const instrumentsAmount = instrumentsPrice; // 100% para dueño
+    const totalPrice = roomPrice + instrumentsPrice;
+
+    booking.totalPrice = totalPrice;
+
+    // 🔹 Crear PaymentIntent en Stripe
+    const paymentIntent = await this.stripe.paymentIntents.create({
+      amount: Math.round(totalPrice * 100), // centavos
+      currency: 'usd',
+      metadata: {
+        bookingId: booking.id,
+        studioId: booking.studio.id,
+        roomId: booking.room.id,
+        instruments: instrumentsList.map((i) => i.id).join(','),
+        roomCommission: roomCommission.toFixed(2),
+        roomOwnerAmount: roomOwnerAmount.toFixed(2),
+        instrumentsAmount: instrumentsAmount.toFixed(2),
+      },
+    });
+
+    booking.paymentIntentId = paymentIntent.id;
+    booking.paymentStatus = 'PENDING';
+    await this.bookingRepo.save(booking);
+
+    return {
+      clientSecret: paymentIntent.client_secret ?? '',
+      bookingId: booking.id,
+      paymentIntentId: paymentIntent.id,
+      totalPrice,
+    };
+  }
+
+  // 🔹 Pago de membresía para dueños
+  async createMembershipPayment(
+    user: User,
+    dto: CreateMembershipPaymentDto,
+  ): Promise<{ clientSecret: string; amount: number }> {
+    if (user.role !== UserRole.STUDIO_OWNER) {
+      throw new ForbiddenException(
+        'Solo dueños de estudio pueden pagar membresía',
+      );
+    }
+
+    const amount = dto.plan === MembershipPlan.MONTHLY ? 79.9 : 799;
+
+    const paymentIntent = await this.stripe.paymentIntents.create({
+      amount: Math.round(amount * 100),
+      currency: 'usd',
+      metadata: {
+        userId: user.id,
+        studioId: user.studio?.id ?? '',
+        membershipPlan: dto.plan,
+      },
+    });
+
+    return { clientSecret: paymentIntent.client_secret ?? '', amount };
+  }
+
+  // 🔹 Confirmar pago (reserva o membresía)
+  async confirmPayment(
+    paymentIntentId: string,
+  ): Promise<
+    Booking | { studioId: string; isActive: boolean } | Stripe.PaymentIntent
+  > {
+    const paymentIntent =
+      await this.stripe.paymentIntents.retrieve(paymentIntentId);
+
+    // 🔹 Caso pago de reserva
+    const booking = await this.bookingRepo.findOne({
+      where: { paymentIntentId },
+      relations: ['room', 'studio', 'musician'],
+    });
+
+    if (booking) {
+      if (paymentIntent.status === 'succeeded') {
+        booking.isPaid = true;
+        booking.paymentStatus = 'SUCCEEDED';
+      } else {
+        booking.paymentStatus = 'FAILED';
+      }
+      await this.bookingRepo.save(booking);
+      return booking;
+    }
+
+    // 🔹 Caso pago de membresía
+    const studioId = paymentIntent.metadata?.studioId;
+    if (studioId) {
+      const studio = await this.studioRepo.findOne({ where: { id: studioId } });
+      if (!studio) throw new NotFoundException('Studio no encontrado');
+
+      studio.isActive = paymentIntent.status === 'succeeded';
+      await this.studioRepo.save(studio);
+
+      return { studioId: studio.id, isActive: studio.isActive };
+    }
+
+    return paymentIntent;
+  }
+
+  // 🔹 Método auxiliar para calcular horas
+  private getHours(start: Date, end: Date): number {
+    const diffMs = new Date(end).getTime() - new Date(start).getTime();
+    return diffMs / (1000 * 60 * 60);
+  }
+}

--- a/src/studios/entities/studio.entity.ts
+++ b/src/studios/entities/studio.entity.ts
@@ -79,7 +79,7 @@ export class Studio {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ default: true })
+  @Column({ default: false })
   isActive: boolean;
 
   @Column({ type: 'enum', enum: StudioStatus, default: StudioStatus.PENDING })


### PR DESCRIPTION
Se implementó el servicio PaymentsService para manejar pagos de reservas (músicos) y membresías (dueños de estudio) usando Stripe en modo test.

Se agregaron métodos:

createBookingPayment → crea PaymentIntent para reservas y calcula precios de sala e instrumentos, incluyendo comisión de la app.

createMembershipPayment → crea PaymentIntent para membresías según plan (mensual o anual).

confirmPayment → confirma el pago y actualiza el estado de la reserva (isPaid) o la membresía (studio.isActive).

Se calculan correctamente precios, comisiones y metadata para Stripe, y se guardan los IDs de PaymentIntent en la base de datos.

Se incluyó validación de roles (MUSICIAN y STUDIO_OWNER) y de estados (reserva ya pagada, estudio activo).

Preparado para pruebas en Swagger con Stripe test keys y en frontend usando clientSecret.